### PR TITLE
feat(cms): add UI-based team offboarding with active flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,30 @@ To run this website locally, you will need to have the following software instal
 
 1. Clone the repository (use this command:-  `git clone https://github.com/infraspecdev/infraspec.dev.git` )
 2. Create `<yourfirstname>.md`(change to `your-first-second-name.md` in case of conflict) file in `content/team`.
-3. Add your image in `static/images/team`. Ensure that you use a faceshot and image is not too large(< 2MB).
-4. Push changes in a branch
-5. See Netlify preview to check if everything is working as expected
-6. Get PR merged.
+3. Add `active: true` in the front matter (optional, defaults to active if omitted).
+4. Add your image in `static/images/team`. Ensure that you use a faceshot and image is not too large(< 2MB).
+5. Push changes in a branch
+6. See Netlify preview to check if everything is working as expected
+7. Get PR merged.
+
+### Offboarding a team member
+
+1. Open that member file in `content/team/<name>.md`.
+2. Set `active: false` in front matter.
+3. Open a PR and merge.
+
+This keeps profile content/history in git while automatically hiding the member from `/team/`.
+
+### Manage team from UI (Decap CMS)
+
+1. In Netlify site settings, enable `Identity`.
+2. In Netlify `Identity` settings, enable `Git Gateway`.
+3. Invite editors from Netlify `Identity` tab (or enable open registration only if you want public signup).
+4. Open `/admin/` on your site and log in.
+5. Edit any Team Member and toggle `Active` to offboard from UI.
+6. The UI intentionally shows only essential fields (full name, job title, image, active, bio).
+
+CMS config lives at `static/admin/config.yml` and admin page at `static/admin/index.html`.
 
 ## Contributions
 

--- a/layouts/team/list.html
+++ b/layouts/team/list.html
@@ -20,13 +20,14 @@
 </div>
 
 <div class="container">
+  {{ $activeMembers := where .Pages ".Params.active" "!=" false }}
   <div class="row">
-    {{ range where .Pages.ByWeight ".Params.promoted" true }}
+    {{ range where $activeMembers.ByWeight ".Params.promoted" true }}
     <div class="col-12 col-md-6 mb-2">{{ .Render "summary-large" }}</div>
     {{ end }}
   </div>
   <div class="row  pt-6 pb-6">
-    {{ range where .Pages.ByWeight ".Params.promoted" "!=" true}}
+    {{ range where $activeMembers.ByWeight ".Params.promoted" "!=" true}}
     <div class="col-12 col-md-4 mb-3">{{ .Render "summary" }}</div>
     {{ end }}
   </div>

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,55 @@
+backend:
+  name: git-gateway
+  branch: main
+
+media_folder: static/images/team
+public_folder: images/team
+
+collections:
+  - name: team
+    label: Team Members
+    label_singular: Team Member
+    folder: content/team
+    create: false
+    slug: "{{slug}}"
+    extension: md
+    format: frontmatter
+    fields:
+      - label: Full Name
+        name: title
+        widget: string
+      - label: Job Title
+        name: jobtitle
+        widget: string
+      - label: Profile Image
+        name: image
+        widget: image
+      - label: Active
+        name: active
+        widget: boolean
+        default: true
+        required: false
+        hint: "Offboarding: uncheck this to hide from /team."
+      - label: Bio
+        name: body
+        widget: markdown
+      - label: Internal Name
+        name: name
+        widget: hidden
+        required: false
+      - label: Weight
+        name: weight
+        widget: hidden
+        required: false
+      - label: Promoted
+        name: promoted
+        widget: hidden
+        required: false
+      - label: Draft
+        name: draft
+        widget: hidden
+        required: false
+      - label: Date
+        name: date
+        widget: hidden
+        required: false

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Infraspec Content Manager</title>
+  </head>
+  <body>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script>
+      if (window.netlifyIdentity) {
+        window.netlifyIdentity.on("init", function (user) {
+          if (!user) {
+            window.netlifyIdentity.on("login", function () {
+              document.location.href = "/admin/";
+            });
+          }
+        });
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a simple CMS-based offboarding flow for team profiles.

### Changes

  - Added Decap CMS admin at /admin
  - Added team collection config with a minimal editor form
  - Added active toggle in CMS to hide offboarded members
  - Updated team listing template to exclude active: false profiles
  - Updated README with setup and usage steps for Netlify Identity + Git Gateway