### PR TITLE
feat: Add Marketing Intern job listing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,7 +29,7 @@ enableRobotsTXT = false
   # A role with e.g. `form: 'marketing'` uses the matching URL below; roles without a
   # `form` key fall back to careersFormUrl with the role title auto-filled.
   [params.careersForms]
-    marketing-role = "https://forms.gle/DbkgCcuYRm9597KT8"
+    marketing-role = "https://forms.gle/MPxWVDAL2Adi4N6Q7"
 
   [params.homepage]
     show_contact_box = true      # show / hide the contact box on the homepage

--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,12 @@ enableRobotsTXT = false
   careersFormUrl = "https://docs.google.com/forms/d/e/1FAIpQLSc2MHdRBys8ZYet8ihXh9Otu711RSeMRf7HjmtjNnbv2B5nmA/viewform"
   careersFormRoleEntry = "entry.1078958931"
 
+  # Role-specific application forms, keyed by the `form` value in a role's front matter.
+  # A role with e.g. `form: 'marketing'` uses the matching URL below; roles without a
+  # `form` key fall back to careersFormUrl with the role title auto-filled.
+  [params.careersForms]
+    marketing-role = "https://forms.gle/DbkgCcuYRm9597KT8"
+
   [params.homepage]
     show_contact_box = true      # show / hide the contact box on the homepage
     show_contact_button = false

--- a/content/careers/marketing-intern.md
+++ b/content/careers/marketing-intern.md
@@ -1,0 +1,35 @@
+---
+title: 'Marketing Intern'
+location: 'Domlur, Bangalore (In-Office)'
+weight: 5
+draft: false
+details: |
+  We aren't your typical IT services shop. We're an AI-first product and platform engineering collective built by builders, for builders. We're building a collaborative home where elite engineering meets high-growth ambition — and we need your help making that vision unmistakable to the world.
+
+  **What you will do:**
+  - Extract the magic — dive into our services business, interview our founders, and turn complex high-scale engineering into compelling stories
+  - Own the LinkedIn stage — co-manage our company page and collaborate with leadership on thought leadership and personal branding
+  - Build the content engine — write human, punchy case studies and engineering deep dives that make the tech community tick
+  - Support new GTM fronts — assist with target audience research and messaging alignment whenever we launch new products or initiatives
+  - Measure and pivot — track campaign metrics to see what lands, using data to continuously iterate
+
+  **How your growth looks:**
+  - The Sponge Phase — absorb our voice, understand our core engineering service model, and audit our existing channels
+  - The Co-Pilot Phase — co-own the content calendar, ship assets for our core business, and dip your toes into secondary GTM experiments alongside leadership
+  - The Pilot Phase — run end-to-end content campaigns with high agency and see the inbound impact of your work
+
+  **We'd love to work with someone who is:**
+  - Deeply dependable — you treat deadlines like a confirmed corner-table booking at a premium Koramangala brunch spot on a Sunday morning
+  - High agency — you don't wait for a Jira ticket; you spot a gap, propose a solution, and pivot faster than a Rapido driver navigating Silk Board traffic
+  - Passionate about tech — you love startup culture and find scale and infrastructure genuinely cool (no coding required)
+  - A human writer — you write with clarity and punch, genuinely loathe corporate fluff and generic AI platitudes, and know how to bring the human touch to everything marketing
+
+  **Why us:**
+  - Real backing — direct pairing with a Marketing Lead and face-time with leadership, built on real safety and mentorship
+  - Zero bureaucracy — no unnecessary layers of approvals; if an idea is good and the data backs it up, we ship it
+  - Flip the script — marketing in engineering services is usually dry; this is where it's not
+---
+
+We are looking for a Marketing Intern who is a sharp, high-agency writer passionate about tech and startup culture. You'll work directly with our Marketing Lead to build Infraspec's brand engine — crafting compelling stories, owning our LinkedIn presence, and helping shape how the tech world sees us.
+
+**Skills:** Content writing, LinkedIn marketing, B2B storytelling, campaign analytics, GTM research.

--- a/content/careers/marketing-intern.md
+++ b/content/careers/marketing-intern.md
@@ -3,6 +3,7 @@ title: 'Marketing Intern'
 location: 'Domlur, Bangalore (In-Office)'
 weight: 5
 draft: false
+form: 'marketing-role'
 details: |
   We aren't your typical IT services shop. We're an AI-first product and platform engineering collective built by builders, for builders. We're building a collaborative home where elite engineering meets high-growth ambition — and we need your help making that vision unmistakable to the world.
 

--- a/layouts/careers/single.html
+++ b/layouts/careers/single.html
@@ -13,7 +13,12 @@
       <div class="content career-single-content">{{ .Params.details | markdownify }}</div>
 
       <div class="career-apply-cta mt-4">
-        <a href="{{ .Site.Params.careersFormUrl }}?usp=pp_url&{{ .Site.Params.careersFormRoleEntry }}={{ .Title | urlquery }}" target="_blank" rel="noopener noreferrer" class="button button-primary">Apply Now</a>
+        {{/* Use a role-specific form (front matter `form` key) if set, else the default form with the role auto-filled. */}}
+        {{ $applyUrl := printf "%s?usp=pp_url&%s=%s" .Site.Params.careersFormUrl .Site.Params.careersFormRoleEntry (.Title | urlquery) }}
+        {{ with .Params.form }}
+          {{ $applyUrl = index $.Site.Params.careersForms . }}
+        {{ end }}
+        <a href="{{ $applyUrl }}" target="_blank" rel="noopener noreferrer" class="button button-primary">Apply Now</a>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Adds a new Marketing Intern role to the careers page
- Content sourced from the Marketing Intern JD (Domlur, Bangalore, In-Office)
- Follows existing career listing format with full JD in frontmatter and summary blurb

## Test plan
- [ ] Visit `/careers/marketing-intern/` and verify the page renders correctly
- [ ] Check the role appears in the careers listing page